### PR TITLE
Fixed typo in sxhkdrc

### DIFF
--- a/config/sxhkd/sxhkdrc
+++ b/config/sxhkd/sxhkdrc
@@ -37,7 +37,7 @@ super + control + {h,j,k,l}
 
 # Toggle fullscreen on and off
 super + f
-  crystal --fullscreen
+  crystal --toggle fullscreen
 
 # Toggle floating on and off
 super + o


### PR DESCRIPTION
The option for crystal should be `--toggle fullscreen` not `--fullscreen.`
[Crystal](https://github.com/salman-abedin/crystal) does not have such an option, `--fullscreen.`
