### PR TITLE
simplified sourced files

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -1,16 +1,10 @@
+" source basic config
+source ~/.config/nvim/basic-setting.vim
+
+" source plugin settings
+let PLUG_CFGS=globpath("~/.config/nvim", "plugconfig/*.vim", 0, 1)
 if !exists('g:vscode')
-	source ~/.config/nvim/basic-setting.vim
-	source ~/.config/nvim/plugconfig/vimwiki.vim
-	source ~/.config/nvim/plugconfig/easy-motion.vim
-	source ~/.config/nvim/plugconfig/undotree.vim
-	source ~/.config/nvim/plugconfig/emmet.vim
-	source ~/.config/nvim/plugconfig/table-mode.vim
-	source ~/.config/nvim/plugconfig/goyo.vim
-	source ~/.config/nvim/plugconfig/git-gutter.vim
-	source ~/.config/nvim/plugconfig/vim-airline.vim
-	source ~/.config/nvim/plugconfig/vim-hexokinase.vim
-	source ~/.config/nvim/plugconfig/vim-fzf.vim
-	source ~/.config/nvim/plugconfig/fern.vim
-	source ~/.config/nvim/plugconfig/vim-closetag.vim
-	source ~/.config/nvim/plugconfig/coc.vim
+    for f in PLUG_CFGS
+        exe 'source' f
+    endfor
 endif


### PR DESCRIPTION
no need to spam `source`, just use a `for` loop.

if you want to go a bit more in depth you may do something like this and avoid spamming home as well
```vim
let $RTP=split(&runtimepath, ',')[0]
let $RC=expand("$RTP/init.vim")

let PLUG_CFGS=globpath($RTP, "plug-cfgs/*.vim", 0, 1)
for f in PLUG_CFGS
    exe 'source' f
endfor
```