### PR TITLE
Error correction

### DIFF
--- a/config/lf/lfrc
+++ b/config/lf/lfrc
@@ -143,7 +143,7 @@ map u $view "$f"
 map az zip
 map at tar
 map ag targz
-map ab targz
+map ab tarbz2
 map au unarchive
 
 # Trash Mappings


### PR DESCRIPTION
"ab" was mapped to targz, which should've been tarbz2. 
Corrected the error.